### PR TITLE
Use LU decomposition to invert

### DIFF
--- a/include/dr_bcg/dr_bcg.h
+++ b/include/dr_bcg/dr_bcg.h
@@ -37,5 +37,5 @@ namespace dr_bcg
 
     void get_R(cublasHandle_t &cublasH, float *h_R, const int n, const int m, const float *A, const float *X, const float *B);
 
-    void invert_spd(cusolverDnHandle_t &cusolverH, cusolverDnParams_t &params, float *A, const int n);
+    void invert_square_matrix(cusolverDnHandle_t &cusolverH, cusolverDnParams_t &params, float *A, const int n);
 }

--- a/test/dr_bcg_test.cu
+++ b/test/dr_bcg_test.cu
@@ -199,7 +199,7 @@ TEST(Residual, OutputCorrect)
     CUDA_CHECK(cudaFree(d_X));
 }
 
-TEST(InvertSPD, OutputCorrect)
+TEST(InvertSquareMatrix, OutputCorrect)
 {
     constexpr float tolerance = 0.001;
 
@@ -235,7 +235,7 @@ TEST(InvertSPD, OutputCorrect)
     CUDA_CHECK(cudaMemcpy(d_A_inv, h_A_in.data(), sizeof(float) * h_A_in.size(), cudaMemcpyHostToDevice));
 
     // Operation
-    dr_bcg::invert_spd(cusolverH, cusolverParams, d_A, m);
+    dr_bcg::invert_square_matrix(cusolverH, cusolverParams, d_A, m);
 
     // Test A * A_inv = I
     constexpr float alpha = 1;


### PR DESCRIPTION
Previous method of using Xpotrf + Spotri would result in nan values due to numerical errors. Calculated s'As values would progressively lose their SPD nature, resulting in errors during Xpotrf.